### PR TITLE
Expland templateContext when rendering mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Using context-selector as json
         },
         "tags": {
           "type": "application"
+        },
+        "templateContext": {
+          "name": "templator"
         }
       },
       {
@@ -144,6 +147,9 @@ Using context-selector as json
         },
         "tags": {
           "type": "database"
+        },
+        "templateContext": {
+          "name": "Database"
         }
       }
     ]
@@ -181,6 +187,9 @@ Using context-selector as json
       "tags": {
         "type": "application"
       },
+      "templateContext": {
+        "name": "templator"
+      },
       "renderedTemplate": "# Template file templates/context.njk\n# Mapping file mappings/nested/example.njk\n\n{\"name\":\"templator\"}\n"
     },
     {
@@ -195,6 +204,9 @@ Using context-selector as json
       },
       "tags": {
         "type": "database"
+      },
+      "templateContext": {
+        "name": "Database"
       },
       "renderedTemplate": "# Template file templates/context.njk\n# Mapping file mappings/nested/example.njk\n\n{\"name\":\"Database\"}\n"
     }
@@ -258,6 +270,9 @@ Using context-selector as json
         "tags": {
           "type": "application"
         },
+        "templateContext": {
+          "name": "templator"
+        },
         "renderedTemplate": "# Template file templates/context.njk\n# Mapping file mappings/nested/example.njk\n\n{\"name\":\"templator\"}\n"
       },
       {
@@ -272,6 +287,9 @@ Using context-selector as json
         },
         "tags": {
           "type": "database"
+        },
+        "templateContext": {
+          "name": "Database"
         },
         "renderedTemplate": "# Template file templates/context.njk\n# Mapping file mappings/nested/example.njk\n\n{\"name\":\"Database\"}\n"
       }

--- a/cmds/generate.js
+++ b/cmds/generate.js
@@ -78,11 +78,12 @@ exports.handler = async (args) => {
   const templator = new Templator(args.baseDir, args);
 
   if (args.justMapping) {
-    const mapping = await templator.renderMapping(
+    const { mapping, context } = await templator.renderMapping(
       args.mapping,
       args.contextSelector
     );
-    console.log(JSON.stringify(mapping, null, 2));
+    await templator.expandTemplatesContext(mapping, context);
+    console.log(JSON.stringify({ mapping, context }, null, 2));
     return;
   }
 

--- a/lib/destinations/index.js
+++ b/lib/destinations/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   'tpd-github': require('@gitops-toolbox/tpd-github').TpdGithub,
+  'tpd-filesystem': require('@gitops-toolbox/tpd-filesystem').TpdFilesystem,
   echo: require('./echo'),
 };

--- a/lib/templator.js
+++ b/lib/templator.js
@@ -37,25 +37,34 @@ class Templator {
       contextSelector
     );
     log('Base mapping %o', mapping);
-    await this._expandTemplates(mapping, context, mappingFilepath);
+    await this.expandTemplatesContext(mapping, context);
+    await this._expandTemplates(mapping, mappingFilepath);
     log('Expanded mapping %o', mapping);
     return mapping;
   }
 
-  async _expandTemplates(renderedMapping, mappingContext, mappingFilepath) {
+  async expandTemplatesContext(renderedMapping, mappingContext) {
+    for (const location of renderedMapping.locations) {
+      log('Expand location %o', location);
+
+      location.templateContext =
+        location.templateContext ||
+        (await this.contextParser._selectFromConfig(
+          mappingContext,
+          location.contextSelector
+        ));
+    }
+  }
+
+  async _expandTemplates(renderedMapping, mappingFilepath) {
     log('Destinations rendered into %o', renderedMapping);
 
     for (const location of renderedMapping.locations) {
       log('Expand location %o', location);
 
-      const context = await this.contextParser._selectFromConfig(
-        mappingContext,
-        location.contextSelector
-      );
-      log('Template context %j', context);
       location.renderedTemplate = await this.templates.render(
         location.template,
-        context,
+        location.templateContext,
         this.mappings.getAbsTemplatePath(mappingFilepath)
       );
     }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "@gitops-toolbox/config-loader": "0.0.3",
+    "@gitops-toolbox/tpd-filesystem": "^0.1.0",
     "@gitops-toolbox/tpd-github": "0.1.0",
     "colors": "^1.4.0",
     "debug": "^4.3.1",

--- a/tests/templator.test.js
+++ b/tests/templator.test.js
@@ -22,6 +22,9 @@ tap.test('Given a destination template and a context', (t) => {
             destination: {},
             renderedTemplate: 'size: 5\n',
             tags: {},
+            templateContext: {
+              size: 5,
+            },
           },
         ],
       });
@@ -81,6 +84,9 @@ tap.test('Given a destination template and a context', (t) => {
             destination: {},
             renderedTemplate: 'replication: 5\n',
             tags: {},
+            templateContext: {
+              replicas: 5,
+            },
           },
           {
             template: 'components/database.njk',
@@ -88,6 +94,9 @@ tap.test('Given a destination template and a context', (t) => {
             destination: {},
             renderedTemplate: 'size: 20\n',
             tags: {},
+            templateContext: {
+              size: 20,
+            },
           },
         ],
       });


### PR DESCRIPTION
This helps debugging issues when the template is not rendering,
you can exactly see what the template is receving as input.
